### PR TITLE
fix: access state safely before initial synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated upload and download artifacts actions to v4
 
 ### Fixed
+- fixed how terraform state is accessed before it the initial synchronization
 - links to supported resources in HOWTOs
 - posting PR comments when terraform plan output is very long
 - PR parsing in the update workflow

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -143,6 +143,8 @@
     - [ ] Rename the `$GITHUB_ORGANIZATION_NAME.yml` in `github` to the name of the GitHub organization
 - [ ] Push the changes to `$GITHUB_MGMT_REPOSITORY_DEFAULT_BRANCH`
 
+> [!WARNING] Please note that until you [synchronize GitHub Management with GitHub](#github-management-sync-flow) for the first time, the workflows that depend on Terraform state, like `Fix`, `Plan` or `Apply`, will fail. This is because the state is not yet initialized.
+
 ## GitHub Management Sync Flow
 
 - [ ] Follow [How to synchronize GitHub Management with GitHub?](HOWTOS.md#synchronize-github-management-with-github) to commit the terraform lock and initialize terraform state

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -136,10 +136,10 @@ locals {
         }
       }
     }
-    "state" = {
+    "state" = lookup({
       for mode, item in {
-        for item in local.state.values.root_module.resources : item.mode => item...
-        } : mode => {
+        for item in try(local.state.values.root_module.resources, []) : item.mode => item...
+      } : mode => {
         for type, item in {
           for item in item : item.type => item...
           } : type => {
@@ -152,7 +152,7 @@ locals {
           }
         }
       }
-    }.managed
+    }, "managed", {})
   }
   resources = {
     "github_membership" = {


### PR DESCRIPTION
This PR tries to address feedback received in https://github.com/ipdxco/github-as-code/issues/160

It adds a warning not to expect Fix workflow to work before initial Sync is complete (it would be nice to produce a better error in the workflow in the future).

It also makes sure we access terraform state safely in `locals.tf` before it has been synchronized for the first time. The issue is that the state just after initialization looks like this:

```
{"format_version":"1.0"}
```

while we already expected it to look like this:

```
{"format_version":"1.0","values":{"root_module":{"resources":[...]}}}
```

The latter is only true after the initial synchronization, which puts resources in the state, is complete.