### PR TITLE
Fix unarchiving a repo

### DIFF
--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -1,12 +1,15 @@
 import 'reflect-metadata'
 
+import {Config} from '../yaml/config'
 import {toggleArchivedRepos} from './shared/toggle-archived-repos'
 import {describeAccessChanges} from './shared/describe-access-changes'
 
 import * as core from '@actions/core'
 
 async function run(): Promise<void> {
-  await toggleArchivedRepos()
+  const config = Config.FromPath()
+  await toggleArchivedRepos(config)
+  config.save()
 
   const accessChangesDescription = await describeAccessChanges()
 

--- a/scripts/src/actions/shared/toggle-archived-repos.ts
+++ b/scripts/src/actions/shared/toggle-archived-repos.ts
@@ -2,9 +2,8 @@ import {Config} from '../../yaml/config'
 import {Repository} from '../../resources/repository'
 import {State} from '../../terraform/state'
 
-export async function toggleArchivedRepos(): Promise<void> {
+export async function toggleArchivedRepos(config: Config): Promise<void> {
   const state = await State.New()
-  const config = Config.FromPath()
 
   const resources = state.getAllResources()
   const stateRepositories = state.getResources(Repository)
@@ -21,6 +20,7 @@ export async function toggleArchivedRepos(): Promise<void> {
         r => r.name === configRepository.name
       )
       if (stateRepository !== undefined && stateRepository.archived) {
+        stateRepository.archived = false
         config.addResource(stateRepository)
         for (const resource of resources) {
           if (
@@ -33,6 +33,4 @@ export async function toggleArchivedRepos(): Promise<void> {
       }
     }
   }
-
-  config.save()
 }

--- a/scripts/src/main.ts
+++ b/scripts/src/main.ts
@@ -14,7 +14,11 @@ async function runSync(): Promise<void> {
 }
 
 async function runToggleArchivedRepos(): Promise<void> {
-  await toggleArchivedRepos()
+  const config = Config.FromPath()
+
+  await toggleArchivedRepos(config)
+
+  config.save()
 }
 
 async function run(): Promise<void> {


### PR DESCRIPTION
Before this change, `toggleArchivedRepos` would prevent the unarchiving of a repository because it didn't set the state repo's `archived` property to `false`.