### PR TITLE
Fix issue labels

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -127,12 +127,12 @@ locals {
         "this" = {
           for item in flatten([
             for repository, config in lookup(local.config, "repositories", {}) : [
-              for label, config in lookup(config, "labels", {}) : merge(config, {
+              for name, config in lookup(config, "labels", {}) : merge(config, {
                 repository = repository
-                label      = label
+                name       = name
               })
             ]
-          ]) : lower("${item.repository}:${item.label}") => item
+          ]) : lower("${item.repository}:${item.name}") => item
         }
       }
     }


### PR DESCRIPTION
Regressed in c82ad0793843d80f691805a97ff5a603fad1ce54:

```
Error: Unsupported attribute

  on locals.tf line 135, in locals:
 135:           ]) : lower("${item.repository}:${item.label}") => item

This object does not have an attribute named "label".
```