### PR TITLE
Don't use deprecated GitHub API call

### DIFF
--- a/scripts/src/actions/find-sha-for-plan.ts
+++ b/scripts/src/actions/find-sha-for-plan.ts
@@ -12,7 +12,8 @@ async function findShaForPlan() {
   const pulls = await github.client.paginate(
     github.client.search.issuesAndPullRequests,
     {
-      q: `repository:${context.repo.owner}/${context.repo.repo} ${context.sha} type:pr is:merged`
+      q: `repository:${context.repo.owner}/${context.repo.repo} ${context.sha} type:pr is:merged`,
+      advanced_search: true
     }
   )
 


### PR DESCRIPTION
GitHub is deprecating searching issues/PRs without advanced search [0], so not setting it currently throws a warning. Until September, let's enable it so they're happy.

[0]: https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/#api-support-for-issues-advanced-search