### PR TITLE
chore: unify shared actions signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new args for repositories and branch protection rules
 
 ### Changed
+- Updated the signatures of all the shared actions; now the runAction function will persist the changes to disk while action functions will operate on the in-memory state
 - Synchronization script: to use GitHub API directly instead of relying on TF GH Provider's Data Sources
 - Configuration: replaced multiple JSONs with a single, unified YAML
 - Synchronization script: rewrote the script in JS

--- a/docs/HOWTOS.md
+++ b/docs/HOWTOS.md
@@ -118,7 +118,7 @@ I want to ensure that all the public repositories in my organization have their 
 To do that, I ensure the following content is present in `scripts/src/actions/fix-yaml-config.ts`:
 ```ts
 import 'reflect-metadata'
-import { protectDefaultBranches } from './shared/protect-default-branches'
+import { runProtectDefaultBranches } from './shared/protect-default-branches'
 
-protectDefaultBranches()
+runProtectDefaultBranches()
 ```

--- a/scripts/__tests__/__resources__/github/default.yml
+++ b/scripts/__tests__/__resources__/github/default.yml
@@ -160,27 +160,7 @@ repositories:
     visibility: public
     vulnerability_alerts: false
   rust-sccache-action:
-    advanced_security: false
-    allow_auto_merge: false
-    allow_merge_commit: true
-    allow_rebase_merge: true
-    allow_squash_merge: true
-    archived: false
-    auto_init: false
-    default_branch: main
-    delete_branch_on_merge: false
-    has_downloads: true
-    has_issues: true
-    has_projects: true
-    has_wiki: true
-    is_template: false
-    secret_scanning_push_protection: false
-    secret_scanning: false
-    teams:
-      maintain:
-        - ipdx
-    visibility: public
-    vulnerability_alerts: true
+    archived: true
   tf-aws-gh-runner:
     advanced_security: false
     allow_auto_merge: false

--- a/scripts/__tests__/__resources__/terraform/terraform.tfstate
+++ b/scripts/__tests__/__resources__/terraform/terraform.tfstate
@@ -618,7 +618,7 @@
             "allow_merge_commit": true,
             "allow_rebase_merge": true,
             "allow_squash_merge": true,
-            "archived": false,
+            "archived": true,
             "branches": [
               {
                 "name": "arm64",
@@ -1644,7 +1644,7 @@
             "allow_rebase_merge": true,
             "allow_squash_merge": true,
             "archive_on_destroy": null,
-            "archived": false,
+            "archived": true,
             "auto_init": false,
             "branches": [
               {

--- a/scripts/__tests__/sync.test.ts
+++ b/scripts/__tests__/sync.test.ts
@@ -9,6 +9,7 @@ import {GitHub} from '../src/github'
 import env from '../src/env'
 import {Resource} from '../src/resources/resource'
 import {RepositoryFile} from '../src/resources/repository-file'
+import {toggleArchivedRepos} from '../src/actions/shared/toggle-archived-repos'
 
 test('sync', async () => {
   const yamlConfig = new config.Config('{}')
@@ -17,6 +18,7 @@ test('sync', async () => {
   const expectedYamlConfig = config.Config.FromPath()
 
   await sync(tfConfig, yamlConfig)
+  await toggleArchivedRepos(tfConfig, yamlConfig)
 
   yamlConfig.format()
 

--- a/scripts/__tests__/terraform/state.test.ts
+++ b/scripts/__tests__/terraform/state.test.ts
@@ -12,12 +12,12 @@ test('can retrieve resources from tf state', async () => {
   for (const resourceClass of ResourceConstructors) {
     const classResources = config.getResources(resourceClass)
     expect(classResources).toHaveLength(
-      global.ResourceCounts[resourceClass.name]
+      global.StateResourceCounts[resourceClass.name]
     )
     resources.push(...classResources)
   }
 
-  expect(resources).toHaveLength(global.ResourcesCount)
+  expect(resources).toHaveLength(global.StateResourcesCount)
 })
 
 test('can ignore resource types', async () => {

--- a/scripts/jest.d.ts
+++ b/scripts/jest.d.ts
@@ -1,6 +1,8 @@
 declare global {
-  var ResourceCounts: Record<string, number>
-  var ResourcesCount: number
+  var StateResourceCounts: Record<string, number>
+  var StateResourcesCount: number
+  var ConfigResourceCounts: Record<string, number>
+  var ConfigResourcesCount: number
 }
 
 export {}

--- a/scripts/jest.setup.ts
+++ b/scripts/jest.setup.ts
@@ -58,7 +58,22 @@ GitHub.github = {
   }
 } as GitHub
 
-global.ResourceCounts = {
+global.ConfigResourceCounts = {
+  [Member.name]: 2,
+  [Repository.name]: 7,
+  [Team.name]: 2,
+  [RepositoryCollaborator.name]: 1,
+  [RepositoryBranchProtectionRule.name]: 1,
+  [RepositoryTeam.name]: 6,
+  [TeamMember.name]: 2,
+  [RepositoryFile.name]: 1,
+  [RepositoryLabel.name]: 3
+}
+global.ConfigResourcesCount = Object.values(global.ConfigResourceCounts).reduce(
+  (a, b) => a + b,
+  0
+)
+global.StateResourceCounts = {
   [Member.name]: 2,
   [Repository.name]: 7,
   [Team.name]: 2,
@@ -69,7 +84,7 @@ global.ResourceCounts = {
   [RepositoryFile.name]: 1,
   [RepositoryLabel.name]: 3
 }
-global.ResourcesCount = Object.values(global.ResourceCounts).reduce(
+global.StateResourcesCount = Object.values(global.StateResourceCounts).reduce(
   (a, b) => a + b,
   0
 )

--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -1,17 +1,14 @@
 import 'reflect-metadata'
 
-import {Config} from '../yaml/config'
-import {toggleArchivedRepos} from './shared/toggle-archived-repos'
-import {describeAccessChanges} from './shared/describe-access-changes'
+import {runToggleArchivedRepos} from './shared/toggle-archived-repos'
+import {runDescribeAccessChanges} from './shared/describe-access-changes'
 
 import * as core from '@actions/core'
 
 async function run(): Promise<void> {
-  const config = Config.FromPath()
-  await toggleArchivedRepos(config)
-  config.save()
+  await runToggleArchivedRepos()
 
-  const accessChangesDescription = await describeAccessChanges()
+  const accessChangesDescription = await runDescribeAccessChanges()
 
   core.setOutput(
     'comment',

--- a/scripts/src/actions/format-yaml-config.ts
+++ b/scripts/src/actions/format-yaml-config.ts
@@ -1,4 +1,9 @@
 import 'reflect-metadata'
-import {format} from './shared/format'
+import {Config} from '../yaml/config'
 
-format()
+async function run(): Promise<void> {
+  const config = Config.FromPath()
+  config.save()
+}
+
+run()

--- a/scripts/src/actions/shared/add-file-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-file-to-all-repos.ts
@@ -3,13 +3,24 @@ import {Repository} from '../../resources/repository'
 import {RepositoryFile} from '../../resources/repository-file'
 import * as core from '@actions/core'
 
-export async function addFileToAllRepos(
+async function runAddFileToAllRepos(
   name: string,
   content: string = name,
   repositoryFilter: (repository: Repository) => boolean = () => true
 ): Promise<void> {
   const config = Config.FromPath()
 
+  await addFileToAllRepos(config, name, content, repositoryFilter)
+
+  config.save()
+}
+
+export async function addFileToAllRepos(
+  config: Config,
+  name: string,
+  content: string = name,
+  repositoryFilter: (repository: Repository) => boolean = () => true
+): Promise<void> {
   const repositories = config
     .getResources(Repository)
     .filter(r => !r.archived)
@@ -23,6 +34,4 @@ export async function addFileToAllRepos(
       config.addResource(file)
     }
   }
-
-  config.save()
 }

--- a/scripts/src/actions/shared/add-file-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-file-to-all-repos.ts
@@ -3,7 +3,7 @@ import {Repository} from '../../resources/repository'
 import {RepositoryFile} from '../../resources/repository-file'
 import * as core from '@actions/core'
 
-async function runAddFileToAllRepos(
+export async function runAddFileToAllRepos(
   name: string,
   content: string = name,
   repositoryFilter: (repository: Repository) => boolean = () => true

--- a/scripts/src/actions/shared/add-label-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-label-to-all-repos.ts
@@ -3,7 +3,7 @@ import {Repository} from '../../resources/repository'
 import {RepositoryLabel} from '../../resources/repository-label'
 import * as core from '@actions/core'
 
-export async function addLabelToAllRepos(
+export async function runAddLabelToAllRepos(
   name: string,
   color: string | undefined = undefined,
   description: string | undefined = undefined,
@@ -11,6 +11,18 @@ export async function addLabelToAllRepos(
 ): Promise<void> {
   const config = Config.FromPath()
 
+  await addLabelToAllRepos(config, name, color, description, repositoryFilter)
+
+  config.save()
+}
+
+export async function addLabelToAllRepos(
+  config: Config,
+  name: string,
+  color: string | undefined = undefined,
+  description: string | undefined = undefined,
+  repositoryFilter: (repository: Repository) => boolean = () => true
+): Promise<void> {
   const repositories = config
     .getResources(Repository)
     .filter(r => !r.archived)
@@ -26,6 +38,4 @@ export async function addLabelToAllRepos(
       config.addResource(label)
     }
   }
-
-  config.save()
 }

--- a/scripts/src/actions/shared/describe-access-changes.ts
+++ b/scripts/src/actions/shared/describe-access-changes.ts
@@ -118,10 +118,17 @@ function deepSort(obj: any): any {
   }
 }
 
-export async function describeAccessChanges(): Promise<string> {
+export async function runDescribeAccessChanges(): Promise<string> {
   const state = await State.New()
   const config = Config.FromPath()
 
+  return await describeAccessChanges(state, config)
+}
+
+export async function describeAccessChanges(
+  state: State,
+  config: Config
+): Promise<string> {
   const before = getAccessSummaryFrom(state)
   const after = getAccessSummaryFrom(config)
 

--- a/scripts/src/actions/shared/format.ts
+++ b/scripts/src/actions/shared/format.ts
@@ -1,6 +1,0 @@
-import {Config} from '../../yaml/config'
-
-export async function format(): Promise<void> {
-  const config = Config.FromPath()
-  config.save()
-}

--- a/scripts/src/actions/shared/protect-default-branches.ts
+++ b/scripts/src/actions/shared/protect-default-branches.ts
@@ -2,11 +2,20 @@ import {Config} from '../../yaml/config'
 import {Repository, Visibility} from '../../resources/repository'
 import {RepositoryBranchProtectionRule} from '../../resources/repository-branch-protection-rule'
 
-export async function protectDefaultBranches(
+export async function runProtectDefaultBranches(
   includePrivate: boolean = false
 ): Promise<void> {
   const config = Config.FromPath()
 
+  await protectDefaultBranches(config, includePrivate)
+
+  config.save()
+}
+
+export async function protectDefaultBranches(
+  config: Config,
+  includePrivate: boolean = false
+): Promise<void> {
   const repositories = config.getResources(Repository).filter(r => !r.archived)
 
   for (const repository of repositories) {
@@ -23,6 +32,4 @@ export async function protectDefaultBranches(
       }
     }
   }
-
-  config.save()
 }

--- a/scripts/src/actions/shared/set-property-in-all-repos.ts
+++ b/scripts/src/actions/shared/set-property-in-all-repos.ts
@@ -2,13 +2,24 @@ import {Config} from '../../yaml/config'
 import {Repository} from '../../resources/repository'
 import * as core from '@actions/core'
 
-export async function setPropertyInAllRepos(
+export async function runSetPropertyInAllRepos(
   name: keyof Repository,
   value: any,
   repositoryFilter: (repository: Repository) => boolean = () => true
 ): Promise<void> {
   const config = Config.FromPath()
 
+  await setPropertyInAllRepos(config, name, value, repositoryFilter)
+
+  config.save()
+}
+
+export async function setPropertyInAllRepos(
+  config: Config,
+  name: keyof Repository,
+  value: any,
+  repositoryFilter: (repository: Repository) => boolean = () => true
+): Promise<void> {
   const repositories = config
     .getResources(Repository)
     .filter(r => !r.archived)
@@ -24,6 +35,4 @@ export async function setPropertyInAllRepos(
       config.addResource(repository)
     }
   }
-
-  config.save()
 }

--- a/scripts/src/actions/shared/toggle-archived-repos.ts
+++ b/scripts/src/actions/shared/toggle-archived-repos.ts
@@ -2,9 +2,19 @@ import {Config} from '../../yaml/config'
 import {Repository} from '../../resources/repository'
 import {State} from '../../terraform/state'
 
-export async function toggleArchivedRepos(config: Config): Promise<void> {
+export async function runToggleArchivedRepos(): Promise<void> {
   const state = await State.New()
+  const config = Config.FromPath()
 
+  await toggleArchivedRepos(state, config)
+
+  config.save()
+}
+
+export async function toggleArchivedRepos(
+  state: State,
+  config: Config
+): Promise<void> {
   const resources = state.getAllResources()
   const stateRepositories = state.getResources(Repository)
   const configRepositories = config.getResources(Repository)

--- a/scripts/src/main.ts
+++ b/scripts/src/main.ts
@@ -1,25 +1,6 @@
 import 'reflect-metadata'
-import {sync} from './sync'
-import {State} from './terraform/state'
-import {Config} from './yaml/config'
-import {toggleArchivedRepos} from './actions/shared/toggle-archived-repos'
-
-async function runSync(): Promise<void> {
-  const state = await State.New()
-  const config = Config.FromPath()
-
-  await sync(state, config)
-
-  config.save()
-}
-
-async function runToggleArchivedRepos(): Promise<void> {
-  const config = Config.FromPath()
-
-  await toggleArchivedRepos(config)
-
-  config.save()
-}
+import {runSync} from './sync'
+import {runToggleArchivedRepos} from './actions/shared/toggle-archived-repos'
 
 async function run(): Promise<void> {
   await runSync()

--- a/scripts/src/sync.ts
+++ b/scripts/src/sync.ts
@@ -3,6 +3,15 @@ import {State} from './terraform/state'
 import {Id} from './terraform/schema'
 import {Config} from './yaml/config'
 
+export async function runSync(): Promise<void> {
+  const state = await State.New()
+  const config = Config.FromPath()
+
+  await sync(state, config)
+
+  config.save()
+}
+
 export async function sync(state: State, config: Config): Promise<void> {
   const resources: [Id, Resource][] = []
   for (const resourceClass of ResourceConstructors) {


### PR DESCRIPTION
This is a follow-up to https://github.com/ipdxco/github-as-code/pull/165

It ensures all the shared actions follow the same pattern of:
- the `action` function not touching the files on disk
- the `runAction` function ensuring the changes of the `action` are written to the file system