### PR TITLE
feat: add support for ignoring teams, repositories and users

### DIFF
--- a/scripts/__tests__/terraform/state.test.ts
+++ b/scripts/__tests__/terraform/state.test.ts
@@ -26,14 +26,25 @@ describe('state', () => {
   })
 
   it('can ignore resource types', async () => {
-    const config = await State.New()
+    const state = await State.New()
 
-    assert.equal(config.isIgnored(Repository), false)
+    assert.equal(await state.isIgnored(Repository), false)
 
-    config['_ignoredTypes'] = ['github_repository']
-    await config.refresh()
+    mock.module('../../src/terraform/locals.js', {
+      namedExports: {
+        Locals: {
+          getLocals: () => {
+            return {
+              resource_types: []
+            }
+          }
+        }
+      }
+    })
 
-    assert.equal(config.isIgnored(Repository), true)
+    await state.refresh()
+
+    assert.equal(await state.isIgnored(Repository), true)
   })
 
   it('can ignore resource properties', async () => {

--- a/scripts/src/sync.ts
+++ b/scripts/src/sync.ts
@@ -15,7 +15,8 @@ export async function runSync(): Promise<void> {
 export async function sync(state: State, config: Config): Promise<void> {
   const resources: [Id, Resource][] = []
   for (const resourceClass of ResourceConstructors) {
-    if (!state.isIgnored(resourceClass)) {
+    const isIgnored = await state.isIgnored(resourceClass)
+    if (!isIgnored) {
       const oldResources = config.getResources(resourceClass)
       const newResources = await resourceClass.FromGitHub(oldResources)
       resources.push(...newResources)

--- a/scripts/src/terraform/locals.ts
+++ b/scripts/src/terraform/locals.ts
@@ -3,6 +3,11 @@ import HCL from 'hcl2-parser'
 
 type LocalsSchema = {
   resource_types: string[]
+  ignore: {
+    repositories: string[]
+    teams: string[]
+    users: string[]
+  }
 }
 
 export class Locals {
@@ -10,20 +15,25 @@ export class Locals {
   static getLocals(): LocalsSchema {
     if (Locals.locals === undefined) {
       const locals: LocalsSchema = {
-        resource_types: []
+        resource_types: [],
+        ignore: {
+          repositories: [],
+          teams: [],
+          users: []
+        }
       }
       for (const path of [
         `${process.env.TF_WORKING_DIR}/locals.tf`,
         `${process.env.TF_WORKING_DIR}/locals_override.tf`
       ]) {
         if (fs.existsSync(path)) {
-          const hcl = HCL.parseToObject(fs.readFileSync(path))?.at(0)
-          for (const key of Object.keys(locals)) {
-            const value = hcl?.locals?.at(0)?.[key]
-            if (value !== undefined) {
-              locals[key as keyof LocalsSchema] = value
-            }
-          }
+          const hcl =
+            HCL.parseToObject(fs.readFileSync(path))?.at(0)?.locals?.at(0) ?? {}
+          locals.resource_types = hcl.resource_types ?? locals.resource_types
+          locals.ignore.repositories =
+            hcl.ignore?.repositories ?? locals.ignore.repositories
+          locals.ignore.teams = hcl.ignore?.teams ?? locals.ignore.teams
+          locals.ignore.users = hcl.ignore?.users ?? locals.ignore.users
         }
       }
       this.locals = locals

--- a/scripts/src/terraform/locals.ts
+++ b/scripts/src/terraform/locals.ts
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import HCL from 'hcl2-parser'
+
+type LocalsSchema = {
+  resource_types: string[]
+}
+
+export class Locals {
+  static locals: LocalsSchema
+  static getLocals(): LocalsSchema {
+    if (Locals.locals === undefined) {
+      const locals: LocalsSchema = {
+        resource_types: []
+      }
+      for (const path of [
+        `${process.env.TF_WORKING_DIR}/locals.tf`,
+        `${process.env.TF_WORKING_DIR}/locals_override.tf`
+      ]) {
+        if (fs.existsSync(path)) {
+          const hcl = HCL.parseToObject(fs.readFileSync(path))?.at(0)
+          for (const key of Object.keys(locals)) {
+            const value = hcl?.locals?.at(0)?.[key]
+            if (value !== undefined) {
+              locals[key as keyof LocalsSchema] = value
+            }
+          }
+        }
+      }
+      this.locals = locals
+    }
+    return Locals.locals
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,6 +4,11 @@ locals {
   advanced_security = false
   config            = yamldecode(file("${path.module}/../github/${local.organization}.yml"))
   state             = jsondecode(file("${path.module}/${local.organization}.tfstate.json"))
+  ignore = {
+    "repositories" = []
+    "teams" = []
+    "users" = []
+  }
   sources = {
     "config" = {
       "github_membership" = {


### PR DESCRIPTION
This is a follow-up to the discussion we had in https://github.com/ipdxco/github-as-code/pull/162

In this proposal, I add the following entry to the `locals`, which can be overwritten by the users via `locals_override`:
```
locals {
  ignore = {
    "repositories" = []
    "teams" = []
    "users" = []
  }
```

These new config options will allow ignoring repositories, teams or users, respectively, by name. 

Internally, the values of the ignore arrays will be read by the GitHub client wrapper. This should be more efficient in terms of our GitHub API usage. Let's say we ignore a repository. Then, by applying that ignore on a client level, we will skip retrieving sub-resources, like repository collaborators or branch protection rules, from GitHub entirely.