### PR TITLE
feat: add a shared action for adding a collaborator to all repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- shared action for adding a collaborator to all repositories
 - clean workflow which removes resources from state
 - information on how to handle private GitHub Management repository
 - warning about GitHub Management repository access

--- a/scripts/src/actions/shared/add-collaborator-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-collaborator-to-all-repos.ts
@@ -1,0 +1,53 @@
+import {Config} from '../../yaml/config.js'
+import {Repository} from '../../resources/repository.js'
+import * as core from '@actions/core'
+import {
+  Permission,
+  RepositoryCollaborator
+} from '../../resources/repository-collaborator.js'
+
+export async function runAddCollaboratorToAllRepos(
+  username: string,
+  permission: Permission,
+  repositoryFilter: (repository: Repository) => boolean = (): boolean => true
+): Promise<void> {
+  const config = Config.FromPath()
+
+  await addCollaboratorToAllRepos(
+    config,
+    username,
+    permission,
+    repositoryFilter
+  )
+
+  config.save()
+}
+
+export async function addCollaboratorToAllRepos(
+  config: Config,
+  username: string,
+  permission: Permission,
+  repositoryFilter: (repository: Repository) => boolean = () => true
+): Promise<void> {
+  const collaborators = config
+    .getResources(RepositoryCollaborator)
+    .filter(c => c.username === username)
+
+  const repositories = config
+    .getResources(Repository)
+    .filter(r => !r.archived)
+    .filter(repositoryFilter)
+    .filter(r => !collaborators.some(c => c.repository === r.name))
+
+  for (const repository of repositories) {
+    const collaborator = new RepositoryCollaborator(
+      repository.name,
+      username,
+      permission
+    )
+    core.info(
+      `Adding ${collaborator.username} as a collaborator with ${collaborator.permission} access to ${collaborator.repository} repository`
+    )
+    config.addResource(collaborator)
+  }
+}


### PR DESCRIPTION
This new shared action allows easily adding a collaborator to all repositories in an organization.