### PR TITLE
fix: standardize resource ID format for team repositories

### DIFF
--- a/scripts/src/resources/repository-team.ts
+++ b/scripts/src/resources/repository-team.ts
@@ -22,7 +22,7 @@ export class RepositoryTeam extends String implements Resource {
     const result: [Id, RepositoryTeam][] = []
     for (const team of teams) {
       result.push([
-        `${team.team.id}:${team.repository.name}`,
+        `${team.repository.name}:${team.team.id}`,
         new RepositoryTeam(
           team.repository.name,
           team.team.name,
@@ -40,7 +40,7 @@ export class RepositoryTeam extends String implements Resource {
           resource.type === RepositoryTeam.StateType &&
           resource.mode === 'managed'
         ) {
-          const teamIndex = resource.index.split(`:`).slice(0, -1).join(`:`)
+          const teamIndex = resource.index.split(`:`).slice(1).join(`:`)
           const team = state.values.root_module.resources.find(
             r =>
               r.mode === 'managed' &&
@@ -120,6 +120,6 @@ export class RepositoryTeam extends String implements Resource {
   }
 
   getStateAddress(): string {
-    return `${RepositoryTeam.StateType}.this["${this.team}:${this.repository}"]`
+    return `${RepositoryTeam.StateType}.this["${this.repository}:${this.team}"]`
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -97,7 +97,7 @@ locals {
                 }
               ]
             ])
-          ]) : lower("${item.team}:${item.repository}") => item
+          ]) : lower("${item.repository}:${item.team}") => item
         }
       }
       "github_team_membership" = {


### PR DESCRIPTION
### Summary
Use consistent repository:entity format for both collaborators and team resources.

### Why do you need this?
This came up for me when looking at https://github.com/filecoin-project/github-mgmt/pull/120#issuecomment-2818239975

I used Claude Code to help me.  I shared that 

> Currently `github_repository_collaborator.this["actors-utils:filecoin-helper"]` is `repositoryName:collaborator` which is good, but `github_team_repository.this["filplus-crate-owners:filplus-backend"]` is `team:repositoryName`.  I want to fix that.  I want it to instead be `github_team_repository.this["filplus-backend:filplus-crate-owners"]`

Summary of the actions that were taken:

```
  1. Updated getStateAddress() to use "repository:team" instead of "team:repository"
  2. Modified the index key format in the Terraform locals.tf file to match the new format
  3. Updated the FromGitHub method to use the new ID format
  4. Adjusted the FromState method to correctly parse the new format

With these changes, team repository resources will now be displayed as: github_team_repository.this["filplus-backend:filplus-crate-owners"]
```