### PR TITLE
feat: add support for efficient labels handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new args for repositories and branch protection rules
 
 ### Changed
+- **BREAKING**: added support for efficient labels handling via the `github_issue_labels` resource (please clean `github_issue_label.this.*` from the terraform state and update `locals_override.tf` and `resources_override.tf` before syncing)
 - **BREAKING**: upgraded to terraform 1.12.0 and github provider 6.6.0 (please clean `github_branch_protection.this.*` from the terraform state and update `resources_override.tf` before syncing the upgrade)
 - **BREAKING**: turned scripts into an ESM project (please ensure you remove the following files during the upgrade: `scripts/.eslintignore`, `scripts/.eslintrc.json`, `scripts/jest.config.js`, `jest.d.ts`, `jest.setup.ts`; please update your imports in the `scripts/src/actions/fix-yaml-config.ts` file to include the `.js` extension)
 - **BREAKING**: Updated the signatures of all the shared actions; now the runAction function will persist the changes to disk while action functions will operate on the in-memory state (please update your imports in the `scripts/src/actions/fix-yaml-config.ts` file accordingly)

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -47,7 +47,7 @@ Running the `Sync` GitHub Action workflows refreshes the underlying terraform st
 - [github_team_repository](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository)
 - [github_team_membership](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership)
 - [github_repository_file](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file)
-- [github_issue_label](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label)
+- [github_issue_labels](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_labels)
 
 # Config Fix Rules
 

--- a/scripts/__tests__/__resources__/terraform/locals_override.tf
+++ b/scripts/__tests__/__resources__/terraform/locals_override.tf
@@ -8,7 +8,7 @@ locals {
     "github_team",
     "github_branch_protection",
     "github_repository_file",
-    "github_issue_label"
+    "github_issue_labels"
   ]
   ignore = {
     "repositories" = ["ignored"]

--- a/scripts/__tests__/__resources__/terraform/resources.tf
+++ b/scripts/__tests__/__resources__/terraform/resources.tf
@@ -38,7 +38,7 @@ resource "github_repository_file" "this" {
     ignore_changes = []
   }
 }
-resource "github_issue_label" "this" {
+resource "github_issue_labels" "this" {
   lifecycle {
     ignore_changes = []
   }

--- a/scripts/__tests__/__resources__/terraform/terraform.tfstate
+++ b/scripts/__tests__/__resources__/terraform/terraform.tfstate
@@ -2053,19 +2053,29 @@
           ]
         },
         {
-          "address": "github_issue_label.this[\"github-action-releaser:topic/ci\"]",
+          "address": "github_issue_labels.this[\"github-action-releaser\"]",
           "mode": "managed",
-          "type": "github_issue_label",
+          "type": "github_issue_labels",
           "name": "this",
-          "index": "github-action-releaser:topic/ci",
+          "index": "github-action-releaser",
           "provider_name": "registry.terraform.io/integrations/github",
           "schema_version": 0,
           "values": {
             "repository": "github-action-releaser",
-            "name": "topic/ci",
-            "color": "#57cc2c",
-            "description": "Topic CI",
-            "url": "https://github.com/pl-strflt/github-action-releaser/labels/topic%2Fci"
+            "label": [
+              {
+                "name": "topic/ci",
+                "color": "#57cc2c",
+                "description": "Topic CI",
+                "url": "https://github.com/pl-strflt/github-action-releaser/labels/topic%2Fci"
+              },
+              {
+                "name": "topic dx",
+                "color": "#57cc2c",
+                "description": "Topic DX",
+                "url": "https://github.com/pl-strflt/github-action-releaser/labels/topic%20dx"
+              }
+            ]
           },
           "sensitive_values": {},
           "depends_on": [
@@ -2073,39 +2083,23 @@
           ]
         },
         {
-          "address": "github_issue_label.this[\"github-action-releaser:topic dx\"]",
+          "address": "github_issue_labels.this[\"projects-status-history\"]",
           "mode": "managed",
-          "type": "github_issue_label",
+          "type": "github_issue_labels",
           "name": "this",
-          "index": "github-action-releaser:topic dx",
-          "provider_name": "registry.terraform.io/integrations/github",
-          "schema_version": 0,
-          "values": {
-            "repository": "github-action-releaser",
-            "name": "topic dx",
-            "color": "#57cc2c",
-            "description": "Topic DX",
-            "url": "https://github.com/pl-strflt/github-action-releaser/labels/topic%20dx"
-          },
-          "sensitive_values": {},
-          "depends_on": [
-            "github_repository.this"
-          ]
-        },
-        {
-          "address": "github_issue_label.this[\"projects-status-history:stale\"]",
-          "mode": "managed",
-          "type": "github_issue_label",
-          "name": "this",
-          "index": "projects-status-history:stale",
+          "index": "projects-status-history",
           "provider_name": "registry.terraform.io/integrations/github",
           "schema_version": 0,
           "values": {
             "repository": "projects-status-history",
-            "name": "stale",
-            "color": "#57cc2c",
-            "description": "Stale",
-            "url": "https://github.com/pl-strflt/projects-status-history/labels/stale"
+            "label": [
+              {
+                "name": "stale",
+                "color": "#57cc2c",
+                "description": "Stale",
+                "url": "https://github.com/pl-strflt/projects-status-history/labels/stale"
+              }
+            ]
           },
           "sensitive_values": {},
           "depends_on": [

--- a/scripts/__tests__/terraform/state.test.ts
+++ b/scripts/__tests__/terraform/state.test.ts
@@ -63,10 +63,10 @@ describe('state', () => {
   it('can add and remove resources through sync', async () => {
     const config = await State.New()
 
-    const addResourceMock = mock.fn(config.addResource.bind(config))
+    const addResourceAtMock = mock.fn(config.addResourceAt.bind(config))
     const removeResourceAtMock = mock.fn(config.removeResourceAt.bind(config))
 
-    config.addResource = addResourceMock
+    config.addResourceAt = addResourceAtMock
     config.removeResourceAt = removeResourceAtMock
 
     const desiredResources: [Id, Resource][] = []
@@ -74,10 +74,13 @@ describe('state', () => {
 
     await config.sync(desiredResources)
 
-    assert.equal(addResourceMock.mock.calls.length, 0)
-    assert.equal(removeResourceAtMock.mock.calls.length, resources.length)
+    assert.equal(addResourceAtMock.mock.calls.length, 0)
+    assert.equal(
+      removeResourceAtMock.mock.calls.length,
+      new Set(resources.map(r => r.getStateAddress().toLowerCase())).size
+    )
 
-    addResourceMock.mock.resetCalls()
+    addResourceAtMock.mock.resetCalls()
     removeResourceAtMock.mock.resetCalls()
 
     for (const resource of resources) {
@@ -85,10 +88,10 @@ describe('state', () => {
     }
 
     await config.sync(desiredResources)
-    assert.equal(addResourceMock.mock.calls.length, 1) // adding github-mgmt/readme.md
+    assert.equal(addResourceAtMock.mock.calls.length, 1) // adding github-mgmt/readme.md
     assert.equal(removeResourceAtMock.mock.calls.length, 1) // removing github-mgmt/README.md
 
-    addResourceMock.mock.resetCalls()
+    addResourceAtMock.mock.resetCalls()
     removeResourceAtMock.mock.resetCalls()
 
     desiredResources.push(['id', new Repository('test')])
@@ -99,7 +102,7 @@ describe('state', () => {
     await config.sync(desiredResources)
 
     assert.equal(
-      addResourceMock.mock.calls.length,
+      addResourceAtMock.mock.calls.length,
       1 + desiredResources.length - resources.length
     )
     assert.equal(removeResourceAtMock.mock.calls.length, 1)

--- a/scripts/src/resources/repository-label.ts
+++ b/scripts/src/resources/repository-label.ts
@@ -6,7 +6,7 @@ import {Id, StateSchema} from '../terraform/schema.js'
 
 @Exclude()
 export class RepositoryLabel implements Resource {
-  static StateType = 'github_issue_label' as const
+  static StateType = 'github_issue_labels' as const
   static async FromGitHub(
     _labels: RepositoryLabel[]
   ): Promise<[Id, RepositoryLabel][]> {
@@ -15,7 +15,7 @@ export class RepositoryLabel implements Resource {
     const result: [Id, RepositoryLabel][] = []
     for (const label of labels) {
       result.push([
-        `${label.repository.name}:${label.label.name}`,
+        label.repository.name,
         new RepositoryLabel(label.repository.name, label.label.name)
       ])
     }
@@ -29,15 +29,14 @@ export class RepositoryLabel implements Resource {
           resource.type === RepositoryLabel.StateType &&
           resource.mode === 'managed'
         ) {
-          labels.push(
-            plainToClassFromExist(
-              new RepositoryLabel(
-                resource.values.repository,
-                resource.values.name
-              ),
-              resource.values
+          for (const label of resource.values.label ?? []) {
+            labels.push(
+              plainToClassFromExist(
+                new RepositoryLabel(resource.values.repository, label.name),
+                label
+              )
             )
-          )
+          }
         }
       }
     }
@@ -85,6 +84,6 @@ export class RepositoryLabel implements Resource {
   }
 
   getStateAddress(): string {
-    return `${RepositoryLabel.StateType}.this["${this.repository}:${this.name}"]`
+    return `${RepositoryLabel.StateType}.this["${this.repository}"]`
   }
 }

--- a/scripts/src/terraform/schema.ts
+++ b/scripts/src/terraform/schema.ts
@@ -32,10 +32,14 @@ type ResourceSchema = {
       }
     }
   | {
-      type: 'github_issue_label'
+      type: 'github_issue_labels'
       values: {
-        name: string
         repository: string
+        label?: {
+          name: string
+          color: string
+          description: string
+        }[]
       }
     }
   | {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,19 @@ variable "write_delay_ms" {
   type        = number
   default     = 1000
 }
+
+variable "resources" {
+  description = "Resources to import."
+  type = object({
+    github_membership              = optional(map(any), {})
+    github_repository              = optional(map(any), {})
+    github_repository_collaborator = optional(map(any), {})
+    github_branch_protection       = optional(map(any), {})
+    github_team                    = optional(map(any), {})
+    github_team_repository         = optional(map(any), {})
+    github_team_membership         = optional(map(any), {})
+    github_repository_file         = optional(map(any), {})
+    github_issue_labels            = optional(map(any), {})
+  })
+  default = null
+}


### PR DESCRIPTION
This PR updates the implementation of the labels support. It starts using a more efficient `github_issue_labels` resource instead of `github_issue_label`.

It also fixes an import issue discovered during testing that was caused by the terraform 1.12.0 upgrade.

It was tested in https://github.com/probe-lab/github-mgmt which now tracks labels 🥳 