### PR TITLE
Harden GitHub Actions workflows and scripts

### DIFF
--- a/.github/actions/git-config-user/action.yml
+++ b/.github/actions/git-config-user/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - if: github.event_name == 'workflow_dispatch'
       run: |
-        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com>"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         git config --global user.name "${GITHUB_ACTOR}"
       shell: bash
     - if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -24,16 +24,16 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Discover workspaces
         id: workspaces
         run: echo "this=$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)" >> $GITHUB_OUTPUT
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''
@@ -76,9 +76,9 @@ jobs:
         working-directory: terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: read
     name: Prepare
     runs-on: ubuntu-latest
+    environment: read
     outputs:
       workspaces: ${{ steps.workspaces.outputs.this }}
       sha: ${{ steps.sha.outputs.result }}
@@ -23,16 +24,16 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Discover workspaces
         id: workspaces
         run: echo "this=$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)" >> $GITHUB_OUTPUT
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''
@@ -41,9 +42,9 @@ jobs:
       - name: Find sha for plan
         id: sha
         env:
-          GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
-          GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', matrix.workspace)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
-          GITHUB_APP_PEM_FILE: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
+          GITHUB_APP_ID: ${{ secrets.RO_GITHUB_APP_ID }}
+          GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RO_GITHUB_APP_INSTALLATION_ID_{0}', matrix.workspace)] || secrets.RO_GITHUB_APP_INSTALLATION_ID }}
+          GITHUB_APP_PEM_FILE: ${{ secrets.RO_GITHUB_APP_PEM_FILE }}
         run: node lib/actions/find-sha-for-plan.js
         working-directory: scripts
   apply:
@@ -58,6 +59,7 @@ jobs:
         workspace: ${{ fromJson(needs.prepare.outputs.workspaces) }}
     name: Apply
     runs-on: ubuntu-latest
+    environment: write
     env:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
@@ -74,7 +76,7 @@ jobs:
         working-directory: terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -82,12 +84,20 @@ jobs:
           terraform_wrapper: false
       - name: Initialize terraform
         run: terraform init
-      - name: Terraform Plan Download
+      - name: Download reviewed terraform plan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ needs.prepare.outputs.sha }}
         run: gh run download -n "${TF_WORKSPACE}_${SHA}.tfplan" --repo "${GITHUB_REPOSITORY}"
-      - name: Terraform Apply
+      - name: Replan merged commit
         run: |
           terraform show -json > $TF_WORKSPACE.tfstate.json
-          terraform apply -lock-timeout=0s -no-color "${TF_WORKSPACE}.tfplan"
+          terraform plan -refresh=false -lock=false -out="${TF_WORKSPACE}.merged.tfplan" -no-color
+      - name: Compare reviewed and merged plans
+        run: |
+          terraform show -no-color "${TF_WORKSPACE}.tfplan" > "${TF_WORKSPACE}.reviewed.txt"
+          terraform show -no-color "${TF_WORKSPACE}.merged.tfplan" > "${TF_WORKSPACE}.merged.txt"
+          diff -u "${TF_WORKSPACE}.reviewed.txt" "${TF_WORKSPACE}.merged.txt"
+      - name: Terraform Apply
+        run: |
+          terraform apply -lock-timeout=0s -no-color "${TF_WORKSPACE}.merged.tfplan"

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Discover workspaces
         id: workspaces
         env:
@@ -70,9 +70,9 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Discover workspaces
         id: workspaces
         env:
@@ -53,6 +53,7 @@ jobs:
         workspace: ${{ fromJson(needs.prepare.outputs.workspaces) }}
     name: Prepare
     runs-on: ubuntu-latest
+    environment: write
     env:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
@@ -69,7 +70,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -38,13 +38,13 @@ jobs:
       TF_WORKSPACE: ${{ github.repository_owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -30,6 +30,7 @@ jobs:
       contents: write
     name: Clean Up
     runs-on: ubuntu-latest
+    environment: push # TODO: split into read part and push part
     env:
       GITHUB_APP_ID: ${{ secrets.RO_GITHUB_APP_ID }}
       GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RO_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RO_GITHUB_APP_INSTALLATION_ID }}
@@ -37,13 +38,13 @@ jobs:
       TF_WORKSPACE: ${{ github.repository_owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -35,7 +35,7 @@ jobs:
       skip-fix: ${{ steps.skip-fix.outputs.this }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -83,7 +83,7 @@ jobs:
       TF_VAR_write_delay_ms: 300
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -94,7 +94,7 @@ jobs:
           git fetch origin "pull/${NUMBER}/head"
           rm -rf github && git checkout "${SHA}" -- github
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false
@@ -102,11 +102,11 @@ jobs:
         run: terraform init
         working-directory: terraform
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''
@@ -118,7 +118,7 @@ jobs:
         run: node lib/actions/fix-yaml-config.js
         working-directory: scripts
       - name: Upload YAML config
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.TF_WORKSPACE }}.yml
           path: github/${{ env.TF_WORKSPACE }}.yml
@@ -127,7 +127,7 @@ jobs:
       # NOTE(galargh, 2024-02-15): This will only work if GitHub as Code is used for a single organization
       - name: Comment on pull request
         if: github.event_name == 'pull_request_target' && steps.fix.outputs.comment
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: fix
           number: ${{ github.event.pull_request.number }}
@@ -150,18 +150,18 @@ jobs:
           installation_retrieval_payload: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ steps.token.outputs.token }}
           path: head
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: base
       - name: Download YAML configs
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
       - name: Copy YAML configs

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -35,7 +35,7 @@ jobs:
       skip-fix: ${{ steps.skip-fix.outputs.this }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -70,6 +70,7 @@ jobs:
         workspace: ${{ fromJson(needs.prepare.outputs.workspaces || '[]') }}
     name: Fix
     runs-on: ubuntu-latest
+    environment: read
     env:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
@@ -82,7 +83,7 @@ jobs:
       TF_VAR_write_delay_ms: 300
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -101,11 +102,11 @@ jobs:
         run: terraform init
         working-directory: terraform
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''
@@ -117,7 +118,7 @@ jobs:
         run: node lib/actions/fix-yaml-config.js
         working-directory: scripts
       - name: Upload YAML config
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.TF_WORKSPACE }}.yml
           path: github/${{ env.TF_WORKSPACE }}.yml
@@ -138,9 +139,7 @@ jobs:
       contents: read
     name: Push
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.RO_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.RO_AWS_SECRET_ACCESS_KEY }}
+    environment: push
     steps:
       - name: Generate app token
         id: token
@@ -151,18 +150,18 @@ jobs:
           installation_retrieval_payload: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ steps.token.outputs.token }}
           path: head
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: base
       - name: Download YAML configs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: artifacts
       - name: Copy YAML configs

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     name: Sync
     runs-on: ubuntu-latest
+    environment: write
     env:
       GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
       GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
@@ -35,13 +36,13 @@ jobs:
       TF_WORKSPACE: ${{ github.repository_owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -36,13 +36,13 @@ jobs:
       TF_WORKSPACE: ${{ github.repository_owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -25,7 +25,7 @@ jobs:
       workspaces: ${{ steps.workspaces.outputs.this }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -71,7 +71,7 @@ jobs:
       TF_VAR_write_delay_ms: 300
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -81,7 +81,7 @@ jobs:
           git fetch origin "pull/${NUMBER}/head"
           rm -rf github && git checkout "${SHA}" -- github
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false
@@ -94,7 +94,7 @@ jobs:
           terraform plan -refresh=false -lock=false -out="${TF_WORKSPACE}.tfplan" -no-color
         working-directory: terraform
       - name: Upload terraform plan
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.TF_WORKSPACE }}_${{ github.event.pull_request.head.sha || github.sha }}.tfplan
           path: terraform/${{ env.TF_WORKSPACE }}.tfplan
@@ -114,7 +114,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.RO_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -124,7 +124,7 @@ jobs:
           git fetch origin "pull/${NUMBER}/head"
           rm -rf github && git checkout "${SHA}" -- github
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false
@@ -132,7 +132,7 @@ jobs:
         run: terraform init
         working-directory: terraform
       - name: Download terraform plans
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: terraform
       - name: Show terraform plans
@@ -160,7 +160,7 @@ jobs:
           echo "${delimiter}" >> $GITHUB_ENV
         working-directory: terraform
       - name: Comment on pull request
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: plan
           number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -25,7 +25,7 @@ jobs:
       workspaces: ${{ steps.workspaces.outputs.this }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -58,6 +58,7 @@ jobs:
         workspace: ${{ fromJson(needs.prepare.outputs.workspaces || '[]') }}
     name: Plan
     runs-on: ubuntu-latest
+    environment: read
     env:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
@@ -70,7 +71,7 @@ jobs:
       TF_VAR_write_delay_ms: 300
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -93,7 +94,7 @@ jobs:
           terraform plan -refresh=false -lock=false -out="${TF_WORKSPACE}.tfplan" -no-color
         working-directory: terraform
       - name: Upload terraform plan
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.TF_WORKSPACE }}_${{ github.event.pull_request.head.sha || github.sha }}.tfplan
           path: terraform/${{ env.TF_WORKSPACE }}.tfplan
@@ -107,12 +108,13 @@ jobs:
       pull-requests: write
     name: Comment
     runs-on: ubuntu-latest
+    environment: read
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.RO_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.RO_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - if: github.event_name == 'pull_request_target'
         env:
           NUMBER: ${{ github.event.pull_request.number }}
@@ -130,7 +132,7 @@ jobs:
         run: terraform init
         working-directory: terraform
       - name: Download terraform plans
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: terraform
       - name: Show terraform plans
@@ -138,9 +140,9 @@ jobs:
           for plan in $(find . -type f -name '*.tfplan'); do
             echo "<details><summary>$(basename "${plan}" '.tfplan')</summary>" >> TERRAFORM_PLANS.md
             echo '' >> TERRAFORM_PLANS.md
-            echo '```' >> TERRAFORM_PLANS.md
-            echo "$(terraform show -no-color "${plan}" 2>&1)" >> TERRAFORM_PLANS.md
-            echo '```' >> TERRAFORM_PLANS.md
+            echo '~~~~terraform' >> TERRAFORM_PLANS.md
+            terraform show -no-color "${plan}" 2>&1 | sed 's/^~~~~/~~~~ /' >> TERRAFORM_PLANS.md
+            echo '~~~~' >> TERRAFORM_PLANS.md
             echo '' >> TERRAFORM_PLANS.md
             echo '</details>' >> TERRAFORM_PLANS.md
           done
@@ -148,13 +150,14 @@ jobs:
         working-directory: terraform
       - name: Prepare comment
         run: |
-          echo 'COMMENT<<EOF' >> $GITHUB_ENV
+          delimiter="$(uuidgen)"
+          echo "COMMENT<<${delimiter}" >> $GITHUB_ENV
           if [[ $(wc -c TERRAFORM_PLANS.md | cut -d' ' -f1) -ge 65000 ]]; then
             echo "Terraform plans are too long to post as a comment. Please inspect [Plan > Comment > Show terraform plans](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) instead." >> $GITHUB_ENV
           else
             cat TERRAFORM_PLANS.md >> $GITHUB_ENV
           fi
-          echo 'EOF' >> $GITHUB_ENV
+          echo "${delimiter}" >> $GITHUB_ENV
         working-directory: terraform
       - name: Comment on pull request
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -162,7 +165,7 @@ jobs:
           header: plan
           number: ${{ github.event.pull_request.number }}
           message: |
-            Before merge, verify that all the following plans are correct. They will be applied as-is after the merge.
+            Before merge, verify that all the following plans are correct. After merge, Apply will regenerate the plans from the merged commit and continue only if they match.
 
             #### Terraform plans
             ${{ env.COMMENT }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Discover workspaces
         id: workspaces
         env:
@@ -51,6 +51,7 @@ jobs:
         workspace: ${{ fromJson(needs.prepare.outputs.workspaces) }}
     name: Sync
     runs-on: ubuntu-latest
+    environment: write
     env:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
@@ -67,7 +68,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -92,11 +93,11 @@ jobs:
           terraform show -json > $TF_WORKSPACE.tfstate.json
         working-directory: terraform
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''
@@ -120,6 +121,7 @@ jobs:
     if: needs.prepare.outputs.workspaces != ''
     name: Push
     runs-on: ubuntu-latest
+    environment: push
     defaults:
       run:
         shell: bash
@@ -133,7 +135,7 @@ jobs:
           installation_retrieval_payload: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ steps.token.outputs.token }}
       - uses: ./.github/actions/git-config-user

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Discover workspaces
         id: workspaces
         env:
@@ -68,9 +68,9 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.12.0
           terraform_wrapper: false
@@ -93,11 +93,11 @@ jobs:
           terraform show -json > $TF_WORKSPACE.tfstate.json
         working-directory: terraform
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''
@@ -135,7 +135,7 @@ jobs:
           installation_retrieval_payload: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.token.outputs.token }}
       - uses: ./.github/actions/git-config-user

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,17 +16,18 @@ jobs:
         github.event.workflow_run.conclusion == 'success')
     name: Update
     runs-on: ubuntu-latest
+    environment: push
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,13 +21,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           version: 10
       - name: Use Node.js lts/*
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: ''

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -5,14 +5,14 @@ on:
     inputs:
       ref:
         required: false
-        description: The github-mgmt-template ref to upgrade to
+        description: The github-as-code ref to upgrade to
         default: master
 
 jobs:
   upgrade:
     uses: ipdxco/github-as-code/.github/workflows/upgrade_reusable.yml@master
     with:
-      ref: inputs.ref
+      ref: ${{ inputs.ref }}
     secrets:
       GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
       GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}

--- a/.github/workflows/upgrade_reusable.yml
+++ b/.github/workflows/upgrade_reusable.yml
@@ -34,13 +34,13 @@ jobs:
           installation_retrieval_payload: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.GITHUB_APP_PEM_FILE }}
       - name: Checkout GitHub Management template
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ipdxco/github-as-code
           path: github-as-code-template
           ref: ${{ inputs.ref }}
       - name: Checkout GitHub Management
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: github-mgmt
           token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/upgrade_reusable.yml
+++ b/.github/workflows/upgrade_reusable.yml
@@ -6,7 +6,7 @@ on:
       ref:
         type: string
         required: false
-        description: The github-mgmt-template ref to upgrade to
+        description: The github-as-code ref to upgrade to
         default: master
     secrets:
       GITHUB_APP_ID:
@@ -20,6 +20,7 @@ jobs:
   upgrade:
     name: Upgrade
     runs-on: ubuntu-latest
+    environment: push
     defaults:
       run:
         shell: bash
@@ -33,13 +34,13 @@ jobs:
           installation_retrieval_payload: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.GITHUB_APP_PEM_FILE }}
       - name: Checkout GitHub Management template
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          repository: pl-strflt/github-mgmt-template
-          path: github-mgmt-template
-          ref: ${{ github.event.inputs.ref }}
+          repository: ipdxco/github-as-code
+          path: github-as-code-template
+          ref: ${{ inputs.ref }}
       - name: Checkout GitHub Management
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: github-mgmt
           token: ${{ steps.token.outputs.token }}
@@ -49,13 +50,13 @@ jobs:
             mkdir -p "../github-mgmt/$(dirname "${file}")"
             cp -f "${file}" "../github-mgmt/${file}"
           done
-        working-directory: github-mgmt-template
-      - uses: ./github-mgmt-template/.github/actions/git-config-user
+        working-directory: github-as-code-template
+      - uses: ./github-as-code-template/.github/actions/git-config-user
       - run: |
           git add --all
           git diff-index --quiet HEAD || git commit --message="upgrade@${GITHUB_RUN_ID}"
         working-directory: github-mgmt
-      - uses: ./github-mgmt-template/.github/actions/git-push
+      - uses: ./github-as-code-template/.github/actions/git-push
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new args for repositories and branch protection rules
 
 ### Changed
+- workflows: added separate GitHub Actions environments for reading organization state, writing organization state, and pushing repository changes
+- workflows: pin third-party actions to exact SHAs and replan from the merged commit before applying
+- docs: update template repository references from `github-mgmt-template` to `github-as-code`
+- scripts: update dependencies with security advisories
 - **BREAKING**: added support for efficient labels handling via the `github_issue_labels` resource (please clean `github_issue_label.this.*` from the terraform state and update `locals_override.tf` and `resources_override.tf` before syncing)
 - **BREAKING**: upgraded to terraform 1.12.0 and github provider 6.6.0 (please clean `github_branch_protection.this.*` from the terraform state and update `resources_override.tf` before syncing the upgrade)
 - **BREAKING**: turned scripts into an ESM project (please ensure you remove the following files during the upgrade: `scripts/.eslintignore`, `scripts/.eslintrc.json`, `scripts/jest.config.js`, `jest.d.ts`, `jest.setup.ts`; please update your imports in the `scripts/src/actions/fix-yaml-config.ts` file to include the `.js` extension)
@@ -52,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switched from npm to pnpm
 
 ### Fixed
+- repository collaborator permission detection during sync
+- GraphQL branch protection lookup now passes repository owner and name as variables
+- workflow-dispatch git user email configuration
+- repository file lookup to avoid escaping the configured files directory
+- setup documentation branch protection example
 - include labels in the config resources only if they are explicitly defined in the config
 - always assert state type when creating resources from state
 - do not break long file content lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - workflows: added separate GitHub Actions environments for reading organization state, writing organization state, and pushing repository changes
-- workflows: pin third-party actions to exact SHAs and replan from the merged commit before applying
+- workflows: pin third-party actions to latest release SHAs and replan from the merged commit before applying
 - docs: update template repository references from `github-mgmt-template` to `github-as-code`
 - scripts: update dependencies with security advisories
 - **BREAKING**: added support for efficient labels handling via the `github_issue_labels` resource (please clean `github_issue_label.this.*` from the terraform state and update `locals_override.tf` and `resources_override.tf` before syncing)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![Management Banner](https://github.com/pl-strflt/github-mgmt-template/assets/6688074/15b2101a-149a-4556-a1b5-497b50d77813)
+![Management Banner](https://github.com/ipdxco/github-as-code/assets/6688074/15b2101a-149a-4556-a1b5-497b50d77813)
 
 # GitHub Management as Code
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,7 +1,7 @@
 # Key features
 
 - 2-way sync between GitHub Management and the actual GitHub configuration (including bootstrapping)
-- PR-based configuration change review process which guarantees the reviewed plan is the one being applied
+- PR-based configuration change review process which verifies the reviewed plan still matches the plan generated from the merged commit before applying
 - control over what resources and what properties are managed by GitHub Management
 - auto-upgrades from the template repository
 
@@ -27,7 +27,7 @@ The workflow for introducing changes to GitHub via YAML configuration file is as
 1. Review the plan.
 1. Merge the PR and wait for the GitHub Action workflow triggered on pushes to the default branch to apply it.
 
-Neither creating the terraform plan nor applying it refreshes the underlying terraform state i.e. going through this workflow does **NOT** ask GitHub if the actual GitHub configuration state has changed. This makes the workflow fast and rate limit friendly because the number of requests to GitHub is minimised. This can result in the plan failing to be applied, e.g. if the underlying resource has been deleted. This assumes that YAML configuration is the main source of truth for GitHub configuration state. The plans that are created during the PR GitHub Action workflow are applied exactly as-is after the merge.
+Neither creating the terraform plan nor applying it refreshes the underlying terraform state i.e. going through this workflow does **NOT** ask GitHub if the actual GitHub configuration state has changed. This makes the workflow fast and rate limit friendly because the number of requests to GitHub is minimised. This can result in the plan failing to be applied, e.g. if the underlying resource has been deleted. This assumes that YAML configuration is the main source of truth for GitHub configuration state. The plans that are created during the PR GitHub Action workflow are compared against plans regenerated from the merged commit before applying.
 
 The workflow for synchronising the current GitHub configuration state with YAML configuration file is as follows:
 1. Run the `Sync` GitHub Action workflow and wait for the PR to be created.

--- a/docs/EXAMPLE.yml
+++ b/docs/EXAMPLE.yml
@@ -30,13 +30,14 @@ repositories: # This group defines repositories (https://registry.terraform.io/p
         allows_force_pushes: false
         enforce_admins: false
         require_conversation_resolution: false
-        require_signed_commits: false
+        require_signed_commits: true
         required_linear_history: false
         required_pull_request_reviews:
-          dismiss_stale_reviews: false
+          dismiss_stale_reviews: true
           dismissal_restrictions: [] # This field accepts node IDs (TODO: make this field accept human friendly names too)
           pull_request_bypassers: [] # This field accepts node IDs (TODO: make this field accept human friendly names too)
           require_code_owner_reviews: false
+          require_last_push_approval: true
           required_approving_review_count: 1
           restrict_dismissals: false
         required_status_checks:
@@ -73,7 +74,7 @@ repositories: # This group defines repositories (https://registry.terraform.io/p
     default_branch: master
     delete_branch_on_merge: false
     description: GitHub Management
-    homepage_url: https://github.com/pl-strflt/github-mgmt-template
+    homepage_url: https://github.com/ipdxco/github-as-code
     is_template: false
     vulnerability_alerts: false
     archive_on_destroy: true
@@ -86,7 +87,7 @@ repositories: # This group defines repositories (https://registry.terraform.io/p
         branch: master
         path: /docs
     template:
-      owner: pl-strflt
-      repository: github-mgmt-template
+      owner: ipdxco
+      repository: github-as-code
     topics:
       - github

--- a/docs/HOWTOS.md
+++ b/docs/HOWTOS.md
@@ -11,7 +11,7 @@
 
 *Example*
 
-I want to invite `galargh` as an admin to `pl-strflt` organization through GitHub Management.
+I want to invite `galargh` as an admin to `ipdxco` organization through GitHub Management.
 
 I ensure the YAML configuration file has the following entry:
 ```yaml
@@ -29,7 +29,7 @@ I push my changes to a new branch and create a PR. An admin reviews the PR and m
 
 *Example*
 
-I want to demote `galargh` from being an `admin` of `pl-strflt` organization to a regular `member` through GitHub Management.
+I want to demote `galargh` from being an `admin` of `ipdxco` organization to a regular `member` through GitHub Management.
 
 I change the entry for `galargh` in the YAML configuration file from:
 ```yaml
@@ -54,7 +54,7 @@ I push my changes to a new branch and create a PR. An admin reviews the PR and m
 
 *Example*
 
-I want to be able to configure who the member of the `pl-strflt` organization is through GitHub Management.
+I want to be able to configure who the member of the `ipdxco` organization is through GitHub Management.
 
 I add `github_membership` to `resource_types` array in [terraform/locals_override.tf](../terraform/locals_override.tf). I push my changes to a new branch and create a PR. An admin reviews the PR and merges the PR if everything looks OK. Then, they synchronize GitHub Management with GitHub configuration.
 
@@ -67,7 +67,7 @@ I add `github_membership` to `resource_types` array in [terraform/locals_overrid
 
 *Example*
 
-I do not want to configure the roles of `pl-strflt` organization members through GitHub Management anymore.
+I do not want to configure the roles of `ipdxco` organization members through GitHub Management anymore.
 
 I ensure that `terraform/resources_override.tf` contains the following entry:
 ```tf

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -114,8 +114,9 @@
     </details>
 - [ ] [Install the GitHub Apps](https://docs.github.com/en/developers/apps/managing-github-apps/installing-github-apps) in the GitHub organization for `All repositories`
 
-## GitHub Repository Secrets
+## GitHub Actions Environments and Secrets
 
+- [ ] Create GitHub Actions environments named `read`, `write`, and `push`, and configure protection rules such as required reviewers. Workflows that read organization state reference `read`; workflows that write organization state reference `write`; workflows that push generated changes to the GitHub Management repository reference `push`.
 - [ ] [Create encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-organization) for the GitHub organization and allow the repository to access them (\*replace `$GITHUB_ORGANIZATION_NAME` with the GitHub organization name) - *these secrets are read by the GitHub Action workflows*
     - [ ] Go to `https://github.com/organizations/$GITHUB_ORGANIZATION_NAME/settings/apps/$GITHUB_APP_NAME` and copy the `App ID`
        - [ ] `RO_GITHUB_APP_ID`
@@ -160,7 +161,7 @@
 - [ ] Manually set values that are impossible to control this value via terraform currently
    - [ ] [Set read repository contents permissions for `GITHUB_TOKEN`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)
    - [ ] If the repository is public, [require approval for all outside collaborators](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-required-approval-for-workflows-from-public-forks)
-   - [ ] If the repository is private, [disable sending write tokens or secrets to worfklows from fork pull requests](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-private-repository-forks)
+   - [ ] If the repository is private, [disable sending write tokens or secrets to workflows from fork pull requests](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-private-repository-forks)
 - [ ] Pull remote changes to the default branch
 - [ ] Enable required PRs, peer reviews, status checks and branch up-to-date check on the repository by making sure [github/$ORGANIZATION_NAME.yml](github/$ORGANIZATION_NAME.yml) contains the following entry:
     ```yaml
@@ -169,11 +170,13 @@
         branch_protection:
           $GITHUB_MGMT_REPOSITORY_DEFAULT_BRANCH:
             required_pull_request_reviews:
+              dismiss_stale_reviews: true
+              require_last_push_approval: true
               required_approving_review_count: 1
             required_status_checks:
               contexts:
                 - Comment
-              strict": true
+              strict: true
     ```
 - [ ] Push the changes to a branch other than the default branch
 

--- a/scripts/__tests__/__resources__/files/README.md
+++ b/scripts/__tests__/__resources__/files/README.md
@@ -1,6 +1,6 @@
 # GitHub Management via Terraform: pl-strflt
 
-This repository is responsible for managing GitHub configuration of `pl-strflt` organisation as code with Terraform. It was created from [github-mgmt-template](https://github.com/pl-strflt/github-mgmt-template) and it will receive updates from that repository.
+This repository is responsible for managing GitHub configuration of `pl-strflt` organisation as code with Terraform. It was created from [github-as-code](https://github.com/ipdxco/github-as-code) and it will receive updates from that repository.
 
 **IMPORTANT**: Having write access to GitHub Management repository can be as powerful as having admin access to the organizations managed by that repository.
 

--- a/scripts/__tests__/__resources__/github/default.yml
+++ b/scripts/__tests__/__resources__/github/default.yml
@@ -47,11 +47,12 @@ repositories:
         allows_force_pushes: false
         enforce_admins: false
         require_conversation_resolution: false
-        require_signed_commits: false
+        require_signed_commits: true
         required_linear_history: false
         required_pull_request_reviews:
-          dismiss_stale_reviews: false
+          dismiss_stale_reviews: true
           require_code_owner_reviews: false
+          require_last_push_approval: true
           required_approving_review_count: 1
           restrict_dismissals: false
         required_status_checks:
@@ -78,8 +79,8 @@ repositories:
       triage:
         - ipdx
     template:
-      owner: pl-strflt
-      repository: github-mgmt-template
+      owner: ipdxco
+      repository: github-as-code
     visibility: public
     vulnerability_alerts: false
   ipdx:

--- a/scripts/__tests__/__resources__/terraform/terraform.tfstate
+++ b/scripts/__tests__/__resources__/terraform/terraform.tfstate
@@ -1232,14 +1232,15 @@
             "pattern": "master",
             "repository_id": "R_kgDOHGSVzQ",
             "require_conversation_resolution": false,
-            "require_signed_commits": false,
+            "require_signed_commits": true,
             "required_linear_history": false,
             "required_pull_request_reviews": [
               {
-                "dismiss_stale_reviews": false,
+                "dismiss_stale_reviews": true,
                 "dismissal_restrictions": [],
                 "pull_request_bypassers": [],
                 "require_code_owner_reviews": false,
+                "require_last_push_approval": true,
                 "required_approving_review_count": 1,
                 "restrict_dismissals": false
               }
@@ -1407,8 +1408,8 @@
             "svn_url": "https://github.com/pl-strflt/github-mgmt",
             "template": [
               {
-                "owner": "pl-strflt",
-                "repository": "github-mgmt-template"
+                "owner": "ipdxco",
+                "repository": "github-as-code"
               }
             ],
             "topics": [],
@@ -1792,7 +1793,7 @@
             "commit_email": "piotr.galar@gmail.com",
             "commit_message": "Update README",
             "commit_sha": "ff32de62d3dd9bc01a2dabd8439d413e8a250dfe",
-            "content": "# GitHub Management via Terraform: pl-strflt\n\nThis repository is responsible for managing GitHub configuration of `pl-strflt` organisation as code with Terraform. It was created from [github-mgmt-template](https://github.com/pl-strflt/github-mgmt-template) and it will receive updates from that repository.\n\n**IMPORTANT**: Having write access to GitHub Management repository can be as powerful as having admin access to the organizations managed by that repository.\n\n*NOTE*: Because we don't have merge queue functionality enabled for the repository yet, after a merge, wait for the `Apply` and `Update` workflows to complete before merging any other PRs.\n\nTo learn more, check out:\n- [What is GitHub Management and how does it work?](docs/ABOUT.md)\n- [How to set up GitHub Management?](docs/SETUP.md)\n- [How to work with GitHub Management?](docs/HOWTOS.md)\n",
+            "content": "# GitHub Management via Terraform: pl-strflt\n\nThis repository is responsible for managing GitHub configuration of `pl-strflt` organisation as code with Terraform. It was created from [github-as-code](https://github.com/ipdxco/github-as-code) and it will receive updates from that repository.\n\n**IMPORTANT**: Having write access to GitHub Management repository can be as powerful as having admin access to the organizations managed by that repository.\n\n*NOTE*: Because we don't have merge queue functionality enabled for the repository yet, after a merge, wait for the `Apply` and `Update` workflows to complete before merging any other PRs.\n\nTo learn more, check out:\n- [What is GitHub Management and how does it work?](docs/ABOUT.md)\n- [How to set up GitHub Management?](docs/SETUP.md)\n- [How to work with GitHub Management?](docs/HOWTOS.md)\n",
             "file": "README.md",
             "id": "github-mgmt/README.md",
             "overwrite_on_create": false,

--- a/scripts/__tests__/github.test.ts
+++ b/scripts/__tests__/github.test.ts
@@ -4,6 +4,10 @@ import {before, describe, it} from 'node:test'
 import assert from 'node:assert'
 import {mockGitHub} from './github.js'
 import {GitHub} from '../src/github.js'
+import {
+  Permission,
+  RepositoryCollaborator
+} from '../src/resources/repository-collaborator.js'
 
 describe('github', () => {
   let github: GitHub
@@ -40,9 +44,6 @@ describe('github', () => {
           collaborators: [
             {
               login: 'ignored'
-            },
-            {
-              login: 'unignored'
             }
           ],
           invitations: [
@@ -77,7 +78,40 @@ describe('github', () => {
               login: 'ignored'
             },
             {
-              login: 'unignored'
+              login: 'admin',
+              permissions: {
+                admin: true
+              }
+            },
+            {
+              login: 'maintain',
+              permissions: {
+                maintain: true
+              }
+            },
+            {
+              login: 'push',
+              permissions: {
+                push: true
+              }
+            },
+            {
+              login: 'triage',
+              permissions: {
+                triage: true
+              }
+            },
+            {
+              login: 'pull',
+              permissions: {
+                pull: true
+              }
+            },
+            {
+              login: 'unignored',
+              permissions: {
+                pull: true
+              }
             }
           ],
           invitations: [
@@ -189,6 +223,22 @@ describe('github', () => {
     assert.ok(collaborators.length > 0)
     assert.ok(!collaborators.some(c => c.repository.name === 'ignored'))
     assert.ok(!collaborators.some(c => c.collaborator.login === 'ignored'))
+  })
+
+  it('maps repository collaborator permissions', async () => {
+    const collaborators = await RepositoryCollaborator.FromGitHub([])
+    const permissionsByUsername = new Map(
+      collaborators.map(([, collaborator]) => [
+        collaborator.username,
+        collaborator.permission
+      ])
+    )
+
+    assert.equal(permissionsByUsername.get('admin'), Permission.Admin)
+    assert.equal(permissionsByUsername.get('maintain'), Permission.Maintain)
+    assert.equal(permissionsByUsername.get('push'), Permission.Push)
+    assert.equal(permissionsByUsername.get('triage'), Permission.Triage)
+    assert.equal(permissionsByUsername.get('pull'), Permission.Pull)
   })
 
   it('listRepositoryInvitations', async () => {

--- a/scripts/__tests__/github.ts
+++ b/scripts/__tests__/github.ts
@@ -5,6 +5,13 @@ export interface GitHubConfig {
     name: string
     collaborators?: {
       login: string
+      permissions?: {
+        admin?: boolean
+        maintain?: boolean
+        push?: boolean
+        triage?: boolean
+        pull?: boolean
+      }
     }[]
     branchProtectionRules?: {
       pattern: string
@@ -127,17 +134,20 @@ export function mockGitHub(config: GitHubConfig = {}): void {
             ): Promise<T> {
               return f(opts)
             }
-            async graphql(query: string): Promise<unknown> {
-              // extract owner and repo from query using repository\(owner: \"([^\"]+)\", name: \"([^\"]+)\"\)
-              const match = query.match(
-                /repository\(owner: "([^"]+)", name: "([^"]+)"\)/
-              )
-              if (match === null) {
-                throw new Error(`Could not find repository in query: ${query}`)
+            async graphql(
+              query: string,
+              variables?: {owner: string; name: string}
+            ): Promise<unknown> {
+              if (query.includes('repository(owner: "')) {
+                throw new Error(
+                  `Expected repository variables in query: ${query}`
+                )
               }
-              const [, , repo] = match
+              if (variables === undefined) {
+                throw new Error('Expected GraphQL variables')
+              }
               const nodes =
-                config.repositories?.find(r => r.name === repo)
+                config.repositories?.find(r => r.name === variables.name)
                   ?.branchProtectionRules ?? []
               return {
                 repository: {

--- a/scripts/__tests__/resources/repository-file.test.ts
+++ b/scripts/__tests__/resources/repository-file.test.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import {findFileByContent} from '../../src/resources/repository-file.js'
 import {describe, it} from 'node:test'
 import assert from 'node:assert'
@@ -12,5 +14,23 @@ describe('repository file', () => {
       fileContent
     )
     assert.equal(foundFilePath, filePath)
+  })
+
+  it('does not follow paths outside the base directory', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repository-file-'))
+    const outsideDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'repository-file-')
+    )
+    try {
+      fs.writeFileSync(path.join(outsideDir, 'secret.txt'), 'secret')
+      fs.symlinkSync(outsideDir, path.join(baseDir, 'outside'), 'dir')
+
+      const foundFilePath = findFileByContent(baseDir, 'secret')
+
+      assert.equal(foundFilePath, undefined)
+    } finally {
+      fs.rmSync(baseDir, {recursive: true, force: true})
+      fs.rmSync(outsideDir, {recursive: true, force: true})
+    }
   })
 })

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -46,20 +46,5 @@
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "@isaacs/brace-expansion@<=5.0.0": "5.0.1",
-      "ajv@<6.14.0": "6.14.0",
-      "brace-expansion@<1.1.13": "1.1.14",
-      "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
-      "flatted@<=3.4.1": "3.4.2",
-      "glob": "^11.1.0",
-      "js-yaml": "^4.1.1",
-      "minimatch@<3.1.4": "3.1.5",
-      "minimatch@>=9.0.0 <9.0.7": "9.0.9",
-      "minimatch@>=10.0.0 <10.2.3": "10.2.5",
-      "picomatch@<2.3.2": "2.3.2"
-    }
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,9 +17,9 @@
     "main": "node lib/main.js"
   },
   "dependencies": {
-    "@actions/core": "^1.11.1",
-    "@actions/exec": "^1.1.1",
-    "@actions/github": "^6.0.1",
+    "@actions/core": "^3.0.0",
+    "@actions/exec": "^3.0.0",
+    "@actions/github": "^9.1.0",
     "@octokit/auth-app": "^8.1.2",
     "@octokit/core": "^7.0.6",
     "@octokit/graphql": "^9.0.3",
@@ -31,7 +31,7 @@
     "deep-diff": "^1.0.2",
     "hcl2-parser": "^1.0.3",
     "reflect-metadata": "^0.2.2",
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -49,8 +49,17 @@
   },
   "pnpm": {
     "overrides": {
+      "@isaacs/brace-expansion@<=5.0.0": "5.0.1",
+      "ajv@<6.14.0": "6.14.0",
+      "brace-expansion@<1.1.13": "1.1.14",
+      "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
+      "flatted@<=3.4.1": "3.4.2",
       "glob": "^11.1.0",
-      "js-yaml": "^4.1.1"
+      "js-yaml": "^4.1.1",
+      "minimatch@<3.1.4": "3.1.5",
+      "minimatch@>=9.0.0 <9.0.7": "9.0.9",
+      "minimatch@>=10.0.0 <10.2.3": "10.2.5",
+      "picomatch@<2.3.2": "2.3.2"
     }
   }
 }

--- a/scripts/pnpm-lock.yaml
+++ b/scripts/pnpm-lock.yaml
@@ -4,19 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@isaacs/brace-expansion@<=5.0.0': 5.0.1
-  ajv@<6.14.0: 6.14.0
-  brace-expansion@<1.1.13: 1.1.14
-  brace-expansion@>=2.0.0 <2.0.3: 2.0.3
-  flatted@<=3.4.1: 3.4.2
-  glob: ^11.1.0
-  js-yaml: ^4.1.1
-  minimatch@<3.1.4: 3.1.5
-  minimatch@>=9.0.0 <9.0.7: 9.0.9
-  minimatch@>=10.0.0 <10.2.3: 10.2.5
-  picomatch@<2.3.2: 2.3.2
-
 importers:
 
   .:

--- a/scripts/pnpm-lock.yaml
+++ b/scripts/pnpm-lock.yaml
@@ -5,22 +5,31 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@isaacs/brace-expansion@<=5.0.0': 5.0.1
+  ajv@<6.14.0: 6.14.0
+  brace-expansion@<1.1.13: 1.1.14
+  brace-expansion@>=2.0.0 <2.0.3: 2.0.3
+  flatted@<=3.4.1: 3.4.2
   glob: ^11.1.0
   js-yaml: ^4.1.1
+  minimatch@<3.1.4: 3.1.5
+  minimatch@>=9.0.0 <9.0.7: 9.0.9
+  minimatch@>=10.0.0 <10.2.3: 10.2.5
+  picomatch@<2.3.2: 2.3.2
 
 importers:
 
   .:
     dependencies:
       '@actions/core':
-        specifier: ^1.11.1
-        version: 1.11.1
+        specifier: ^3.0.0
+        version: 3.0.0
       '@actions/exec':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^3.0.0
+        version: 3.0.0
       '@actions/github':
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^9.1.0
+        version: 9.1.0
       '@octokit/auth-app':
         specifier: ^8.1.2
         version: 8.1.2
@@ -55,8 +64,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       yaml:
-        specifier: ^2.8.1
-        version: 2.8.1
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -97,20 +106,23 @@ importers:
 
 packages:
 
-  '@actions/core@1.11.1':
-    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+  '@actions/core@3.0.0':
+    resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
 
-  '@actions/exec@1.1.1':
-    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
 
-  '@actions/github@6.0.1':
-    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+  '@actions/github@9.1.0':
+    resolution: {integrity: sha512-u0hDGQeCS+7VNoLA8hYG65RLdPLMaPGfka0sZ0up7P0AiShqfX6xcuXNteGkQ7X7Tod7AMNwHd4p7DS63i8zzA==}
 
-  '@actions/http-client@2.2.3':
-    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
 
-  '@actions/io@1.1.3':
-    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+  '@actions/http-client@4.0.0':
+    resolution: {integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -306,10 +318,6 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -325,14 +333,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -366,17 +366,9 @@ packages:
     resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
     engines: {node: '>= 20'}
 
-  '@octokit/auth-token@4.0.0':
-    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
-    engines: {node: '>= 18'}
-
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
-
-  '@octokit/core@5.2.2':
-    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
-    engines: {node: '>= 18'}
 
   '@octokit/core@7.0.6':
     resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
@@ -386,13 +378,9 @@ packages:
     resolution: {integrity: sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==}
     engines: {node: '>= 20'}
 
-  '@octokit/endpoint@9.0.6':
-    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/graphql@7.1.1':
-    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
-    engines: {node: '>= 18'}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
   '@octokit/graphql@9.0.3':
     resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
@@ -406,12 +394,6 @@ packages:
     resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
     engines: {node: '>= 20'}
 
-  '@octokit/openapi-types@20.0.0':
-    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
-
-  '@octokit/openapi-types@24.2.0':
-    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
-
   '@octokit/openapi-types@27.0.0':
     resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
@@ -421,23 +403,11 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/plugin-paginate-rest@9.2.2':
-    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
   '@octokit/plugin-request-log@6.0.0':
     resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=6'
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1':
-    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
 
   '@octokit/plugin-rest-endpoint-methods@17.0.0':
     resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
@@ -457,31 +427,25 @@ packages:
     peerDependencies:
       '@octokit/core': ^7.0.0
 
-  '@octokit/request-error@5.1.1':
-    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
-    engines: {node: '>= 18'}
-
   '@octokit/request-error@7.0.2':
     resolution: {integrity: sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
   '@octokit/request@10.0.6':
     resolution: {integrity: sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@8.4.1':
-    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
-    engines: {node: '>= 18'}
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
 
   '@octokit/rest@22.0.1':
     resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
     engines: {node: '>= 20'}
-
-  '@octokit/types@12.6.0':
-    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
-
-  '@octokit/types@13.10.0':
-    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
@@ -571,8 +535,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -596,8 +560,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -605,11 +570,15 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -655,12 +624,10 @@ packages:
 
   deep-diff@1.0.2:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -780,8 +747,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -874,6 +841,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -905,15 +875,15 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.2:
@@ -929,9 +899,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -964,8 +931,8 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   prelude-ls@1.2.1:
@@ -1104,15 +1071,12 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   universal-github-app-jwt@2.2.2:
     resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
-
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -1137,11 +1101,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -1151,31 +1112,36 @@ packages:
 
 snapshots:
 
-  '@actions/core@1.11.1':
+  '@actions/core@3.0.0':
     dependencies:
-      '@actions/exec': 1.1.1
-      '@actions/http-client': 2.2.3
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.0
 
-  '@actions/exec@1.1.1':
+  '@actions/exec@3.0.0':
     dependencies:
-      '@actions/io': 1.1.3
+      '@actions/io': 3.0.2
 
-  '@actions/github@6.0.1':
+  '@actions/github@9.1.0':
     dependencies:
-      '@actions/http-client': 2.2.3
-      '@octokit/core': 5.2.2
-      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
-      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      undici: 5.29.0
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      undici: 6.24.1
 
-  '@actions/http-client@2.2.3':
+  '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 5.29.0
+      undici: 6.24.1
 
-  '@actions/io@1.1.3': {}
+  '@actions/http-client@4.0.0':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.24.1
+
+  '@actions/io@3.0.2': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1266,7 +1232,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1280,14 +1246,14 @@ snapshots:
 
   '@eslint/eslintrc@3.3.1':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -1301,8 +1267,6 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@fastify/busboy@2.1.1': {}
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1313,12 +1277,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -1375,19 +1333,7 @@ snapshots:
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/auth-token@4.0.0': {}
-
   '@octokit/auth-token@6.0.0': {}
-
-  '@octokit/core@5.2.2':
-    dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/graphql': 7.1.1
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
 
   '@octokit/core@7.0.6':
     dependencies:
@@ -1404,16 +1350,10 @@ snapshots:
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@9.0.6':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/graphql@7.1.1':
-    dependencies:
-      '@octokit/request': 8.4.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
   '@octokit/graphql@9.0.3':
     dependencies:
@@ -1430,10 +1370,6 @@ snapshots:
       '@octokit/request-error': 7.0.2
       '@octokit/types': 16.0.0
 
-  '@octokit/openapi-types@20.0.0': {}
-
-  '@octokit/openapi-types@24.2.0': {}
-
   '@octokit/openapi-types@27.0.0': {}
 
   '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
@@ -1441,19 +1377,9 @@ snapshots:
       '@octokit/core': 7.0.6
       '@octokit/types': 16.0.0
 
-  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
-    dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
-
   '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/core': 7.0.6
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
-    dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
 
   '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
     dependencies:
@@ -1473,13 +1399,11 @@ snapshots:
       '@octokit/types': 16.0.0
       bottleneck: 2.19.5
 
-  '@octokit/request-error@5.1.1':
-    dependencies:
-      '@octokit/types': 13.10.0
-      deprecation: 2.3.1
-      once: 1.4.0
-
   '@octokit/request-error@7.0.2':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
     dependencies:
       '@octokit/types': 16.0.0
 
@@ -1491,12 +1415,14 @@ snapshots:
       fast-content-type-parse: 3.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/request@8.4.1':
+  '@octokit/request@10.0.8':
     dependencies:
-      '@octokit/endpoint': 9.0.6
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
 
   '@octokit/rest@22.0.1':
     dependencies:
@@ -1504,14 +1430,6 @@ snapshots:
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
       '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
-
-  '@octokit/types@12.6.0':
-    dependencies:
-      '@octokit/openapi-types': 20.0.0
-
-  '@octokit/types@13.10.0':
-    dependencies:
-      '@octokit/openapi-types': 24.2.0
 
   '@octokit/types@16.0.0':
     dependencies:
@@ -1599,7 +1517,7 @@ snapshots:
       debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       semver: 7.7.3
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -1628,7 +1546,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -1649,20 +1567,24 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  before-after-hook@2.2.3: {}
+  balanced-match@4.0.4: {}
 
   before-after-hook@4.0.0: {}
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -1700,8 +1622,6 @@ snapshots:
   deep-diff@1.0.2: {}
 
   deep-is@0.1.4: {}
-
-  deprecation@2.3.1: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -1776,7 +1696,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -1795,7 +1715,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -1856,10 +1776,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -1885,7 +1805,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -1935,6 +1855,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-with-bigint@3.5.8: {}
+
   json5@2.2.3: {}
 
   keyv@4.5.4:
@@ -1959,19 +1881,19 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
-  minimatch@10.1.1:
+  minimatch@10.2.5:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.5
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minipass@7.1.2: {}
 
@@ -1980,10 +1902,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   normalize-path@3.0.0: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2017,7 +1935,7 @@ snapshots:
       lru-cache: 11.2.2
       minipass: 7.1.2
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   prelude-ls@1.2.1: {}
 
@@ -2136,13 +2054,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.24.1: {}
 
   universal-github-app-jwt@2.2.2: {}
-
-  universal-user-agent@6.0.1: {}
 
   universal-user-agent@7.0.3: {}
 
@@ -2168,8 +2082,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
-  wrappy@1.0.2: {}
-
-  yaml@2.8.1: {}
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}

--- a/scripts/pnpm-workspace.yaml
+++ b/scripts/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 minimumReleaseAge: 40320
 minimumReleaseAgeExclude:
   - glob

--- a/scripts/src/github.ts
+++ b/scripts/src/github.ts
@@ -251,8 +251,8 @@ export class GitHub {
       }: {repository: {branchProtectionRules: {nodes: {pattern: string}[]}}} =
         await this.client.graphql(
           `
-          {
-            repository(owner: "${env.GITHUB_ORG}", name: "${repository.name}") {
+          query($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
               branchProtectionRules(first: 100) {
                 nodes {
                   pattern
@@ -260,7 +260,11 @@ export class GitHub {
               }
             }
           }
-        `
+        `,
+          {
+            owner: env.GITHUB_ORG,
+            name: repository.name
+          }
         )
       repositoryBranchProtectionRules.push(
         ...nodes.map(node => ({repository, branchProtectionRule: node}))

--- a/scripts/src/resources/repository-collaborator.ts
+++ b/scripts/src/resources/repository-collaborator.ts
@@ -36,13 +36,13 @@ export class RepositoryCollaborator extends String implements Resource {
     for (const collaborator of collaborators) {
       let permission: Permission | undefined
       if (collaborator.collaborator.permissions?.admin) {
-        permission = Permission.Triage
-      } else if (collaborator.collaborator.permissions?.maintain) {
-        permission = Permission.Push
-      } else if (collaborator.collaborator.permissions?.push) {
-        permission = Permission.Maintain
-      } else if (collaborator.collaborator.permissions?.triage) {
         permission = Permission.Admin
+      } else if (collaborator.collaborator.permissions?.maintain) {
+        permission = Permission.Maintain
+      } else if (collaborator.collaborator.permissions?.push) {
+        permission = Permission.Push
+      } else if (collaborator.collaborator.permissions?.triage) {
+        permission = Permission.Triage
       } else if (collaborator.collaborator.permissions?.pull) {
         permission = Permission.Pull
       }

--- a/scripts/src/resources/repository-file.ts
+++ b/scripts/src/resources/repository-file.ts
@@ -7,21 +7,46 @@ import env from '../env.js'
 import * as fs from 'fs'
 import * as path from 'path'
 
+function isPathInside(basePath: string, targetPath: string): boolean {
+  const relativePath = path.relative(basePath, targetPath)
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  )
+}
+
 export function findFileByContent(
   dirPath: string,
-  content: string
+  content: string,
+  basePath = dirPath
 ): string | undefined {
+  const baseRealPath = fs.realpathSync(basePath)
+  const dirRealPath = fs.realpathSync(dirPath)
+  if (!isPathInside(baseRealPath, dirRealPath)) {
+    return undefined
+  }
+
   const files = fs.readdirSync(dirPath)
   for (const file of files) {
     const filePath = path.join(dirPath, file)
     const fileStats = fs.lstatSync(filePath)
+    let realFilePath: string
+    try {
+      realFilePath = fs.realpathSync(filePath)
+    } catch {
+      continue
+    }
+    if (!isPathInside(baseRealPath, realFilePath)) {
+      continue
+    }
+
     if (fileStats.isFile()) {
       const fileContent = fs.readFileSync(filePath).toString()
       if (fileContent === content) {
         return filePath
       }
     } else if (fileStats.isDirectory()) {
-      const otherFilePath = findFileByContent(filePath, content)
+      const otherFilePath = findFileByContent(filePath, content, basePath)
       if (otherFilePath) {
         return otherFilePath
       }

--- a/terraform/bootstrap/aws.tf
+++ b/terraform/bootstrap/aws.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket" "this" {
 
   tags = {
     Name = "GitHub Management"
-    Url  = "https://github.com/pl-strflt/github-mgmt-template"
+    Url  = "https://github.com/ipdxco/github-as-code"
   }
 }
 
@@ -58,7 +58,7 @@ resource "aws_dynamodb_table" "this" {
 
   tags = {
     Name = "GitHub Management"
-    Url  = "https://github.com/pl-strflt/github-mgmt-template"
+    Url  = "https://github.com/ipdxco/github-as-code"
   }
 }
 
@@ -67,7 +67,7 @@ resource "aws_iam_user" "ro" {
 
   tags = {
     Name = "GitHub Management"
-    Url  = "https://github.com/pl-strflt/github-mgmt-template"
+    Url  = "https://github.com/ipdxco/github-as-code"
   }
 }
 
@@ -76,7 +76,7 @@ resource "aws_iam_user" "rw" {
 
   tags = {
     Name = "GitHub Management"
-    Url  = "https://github.com/pl-strflt/github-mgmt-template"
+    Url  = "https://github.com/ipdxco/github-as-code"
   }
 }
 


### PR DESCRIPTION
### Summary
Harden GitHub Actions workflows and scripts after the security review by adding `read`, `write`, and `push` environments, pinning third-party actions, checking merged-commit plans before apply, and updating setup/example docs.

### Why do you need this?
This reduces workflow supply-chain risk, limits where sensitive secrets are exposed, and fixes script issues around collaborator permissions, GraphQL query construction, and repository file path containment.

### What else do we need to know?
`upgrade.yml` intentionally continues to call the reusable workflow at `@master`; validation passed with build, lint, format check, tests, audit, workflow YAML parsing, and `git diff --check`.

**DRI:** myself

### Reviewer's Checklist
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
